### PR TITLE
Fixed Check Availability error

### DIFF
--- a/namesilo.php
+++ b/namesilo.php
@@ -2197,7 +2197,7 @@ class Namesilo extends Module
 
         $response = $result->response();
 
-        $available = isset($response->available->{'domain'}) && $response->available->{'domain'} == $domain;
+        $available = isset($response->available->{'domain'}) && $response->available->domain->{'0'} == $domain;
 
         return $available;
     }


### PR DESCRIPTION
The domain search was returning unavailable with all domains. The domain comparision check done inside checkAvailability function was making error so fixed it with simple replacement according to the response received from API.