### PR TITLE
Remove redundant API call

### DIFF
--- a/apis/commands/domains.php
+++ b/apis/commands/domains.php
@@ -176,19 +176,6 @@ class NamesiloDomains
     }
 
     /**
-     * Gets the RegistrarLock status for the requested domain.
-     *
-     * @param array $vars An array of input params including:
-     *
-     *  - domain Domain name to get status
-     * @return NamesiloResponse
-     */
-    public function getRegistrarLock(array $vars)
-    {
-        return $this->api->submit('getDomainInfo', $vars);
-    }
-
-    /**
      * Sets the RegistrarLock status for a domain.
      *
      * @param array $vars An array of input params including:

--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -251,6 +251,7 @@ $lang['Namesilo.domain.CIRALanguage.fr'] = 'French';
 
 // Success messages
 $lang['Namesilo.!success.packages_saved'] = 'The packages have been successfully saved.';
+$lang['Namesilo.!success.epp_code_sent'] = "The EPP Code/Transfer Key has been sent to the administrative contact for this domain name via email.";
 
 // Errors
 $lang['Namesilo.!error.FRLegalType.format'] = 'Please select a valid Legal Type';

--- a/namesilo.php
+++ b/namesilo.php
@@ -2126,6 +2126,14 @@ class Namesilo extends Module
                     if (isset($post['request_epp'])) {
                         $response = $transfer->getEpp(['domain' => $fields->domain]);
                         $this->processResponse($api, $response);
+                        unset($post['request_epp']);
+                        $this->setMessage(
+                            'success',
+                            Language::_(
+                                'Namesilo.!success.epp_code_sent',
+                                true
+                            )
+                        );
                     }
 
                     if (isset($post['whois_privacy_before']) || isset($post['whois_privacy'])) {

--- a/namesilo.php
+++ b/namesilo.php
@@ -2140,22 +2140,20 @@ class Namesilo extends Module
 
                     $vars = (object)$post;
                 }
-            } else {
-                $info = $domains->getDomainInfo(['domain' => $fields->domain]);
-                $info_response = $info->response();
-                if (isset($info_response->private)) {
-                    $vars->whois_privacy = $info_response->private;
-                }
-
-                if (isset($info_response->locked)) {
-                    $vars->registrar_lock = $info_response->locked;
-                }
             }
 
-            if (!isset($info)) {
-                $info = $domains->getDomainInfo(['domain' => $fields->domain]);
+            $info = $domains->getDomainInfo(['domain' => $fields->domain]);
+            $info_response = $info->response();
+
+            if (isset($info_response->private)) {
+                $vars->whois_privacy = $info_response->private;
             }
-            $registrant_id = $info->response(true)['contact_ids']['registrant'];
+
+            if (isset($info_response->locked)) {
+                $vars->registrar_lock = $info_response->locked;
+            }
+
+            $registrant_id = $info_response->contact_ids->registrant;
             $registrant_info = $domains->getContacts(['contact_id' => $registrant_id]);
             $registrant_email = $registrant_info->response()->contact->email;
 

--- a/namesilo.php
+++ b/namesilo.php
@@ -2141,15 +2141,14 @@ class Namesilo extends Module
                     $vars = (object)$post;
                 }
             } else {
-                $response = $domains->getRegistrarLock(['domain' => $fields->domain ])->response();
-                if (isset($response->locked)) {
-                    $vars->registrar_lock = $response->locked;
-                }
-
                 $info = $domains->getDomainInfo(['domain' => $fields->domain]);
                 $info_response = $info->response();
                 if (isset($info_response->private)) {
                     $vars->whois_privacy = $info_response->private;
+                }
+
+                if (isset($info_response->locked)) {
+                    $vars->registrar_lock = $info_response->locked;
                 }
             }
 


### PR DESCRIPTION
First commit -> On the "Settings" tab the `getRegistrarLock` method was just calling `getDomainInfo` resulting in 2 calls to the same API endpoint in a row.
It seems redundant, and on this side of the world it adds close to a second to the page repsonse time.

The second commit was just abritrary chainsawing.