### PR TITLE
Fix issues with audit/sync

### DIFF
--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -61,7 +61,7 @@ $lang['Namesilo.manage.manage_packages.save_packages_btn'] = 'Save Packages';
 
 // Sync renew dates
 $lang['Namesilo.manage.sync_renew_dates.box_title'] = 'Sync Domain Renewal Dates';
-$lang['Namesilo.manage.sync_renew_dates.description'] = "This tool synchronizes a service's renewal date with the domain's actual expiration date, taking into account the suspension threshold (as to ensure auto-renewal doesn't renew the domain if the customer hasn't paid).";
+$lang['Namesilo.manage.sync_renew_dates.description'] = "This tool synchronizes a service's renewal date with the domain's actual expiration date, taking into account the suspension threshold (as to ensure auto-renewal doesn't renew the domain if the customer hasn't paid). Highlighted rows have a difference greater than 9 months (270 days) and should be checked before syncing.";
 $lang['Namesilo.manage.sync_renew_dates.results'] = 'Synchronization Results';
 $lang['Namesilo.manage.sync_renew_dates.out_of_sync'] = 'Out Of Sync Renew Dates';
 $lang['Namesilo.manage.sync_renew_dates.errors'] = 'Errors';

--- a/namesilo.php
+++ b/namesilo.php
@@ -833,8 +833,8 @@ class Namesilo extends Module
             }
 
             // Set view
-            $this->view->set('vars', $vars);
-            $this->view->set('url', $this->base_uri . 'settings/company/modules/addrow/' . $module_row->id);
+            $vars['renew_info_url'] = $this->base_uri . 'settings/company/modules/addrow/' . $module_row->id;
+            $this->view->set('vars', (object)$vars);
 
             return $this->view->fetch();
         } elseif  ($action == 'get_renew_info') {

--- a/namesilo.php
+++ b/namesilo.php
@@ -820,7 +820,7 @@ class Namesilo extends Module
 
             $module_row = $this->getRow();
 
-            $services = $this->Record->select(['services.id', 'services.client_id'])
+            $services = $this->Record->select(['services.id'])
                 ->from('services')
                 ->where('module_row_id', '=', $module_row->id)
                 ->where('status', '=', 'active')

--- a/views/default/audit_domains.pdt
+++ b/views/default/audit_domains.pdt
@@ -18,7 +18,7 @@
                         foreach ($vars->domains as $domain) {
                             ?>
                             <tr>
-                                <td><?php echo $this->Html->ifSet($service['domain']); ?></td>
+                                <td><?php echo $this->Html->ifSet($domain); ?></td>
                                 <td>No corresponding billing record in Blesta.</td>
                             </tr>
                             <?php

--- a/views/default/sync_renew_dates.pdt
+++ b/views/default/sync_renew_dates.pdt
@@ -1,5 +1,5 @@
         <script>
-            var service_ids = JSON.parse('<?php echo json_encode($vars['service_ids']); ?>');
+            var service_ids = JSON.parse('<?php echo json_encode($vars->service_ids); ?>');
             var services_done = 0;
 
             $(function() {
@@ -19,7 +19,7 @@
                 var service_id = service_ids.pop();
                 if(service_id !== undefined) {
                     $.getJSON(
-                        '<?php echo $this->Html->ifSet($url); ?>',
+                        '<?php echo $this->Html->ifSet($vars->renew_info_url); ?>',
                         {
                             'service_id': service_id,
                             'action': 'get_renew_info'

--- a/views/default/sync_renew_dates.pdt
+++ b/views/default/sync_renew_dates.pdt
@@ -1,3 +1,57 @@
+        <script>
+            var service_ids = JSON.parse('<?php echo json_encode($this->Html->ifSet($vars['service_ids']), '[]'); ?>');
+            var services_done = 0;
+
+            $(function() {
+                $('span#services_total').text(service_ids.length);
+                run_check();
+            });
+
+            /**
+             * run_check requests information about a service_id.
+             * As long as service_ids.pop() returns a service_id, it will
+             * continue to call run_check again after a 100 milisecond delay.
+             * The delay is to prevent the NameSilo API from ratelimiting requests
+             */
+            function run_check () {
+                var new_row;
+                var button;
+                var service_id = service_ids.pop();
+                if(service_id !== undefined) {
+                    $.getJSON(
+                        '<?php echo $this->Html->ifSet($url); ?>',
+                        {
+                            'service_id': service_id,
+                            'action': 'get_renew_info'
+                        }
+                    ).done(function (output) {
+                        if(output.hasOwnProperty("error") && !output.error){
+                            new_row = $('<tr></tr>');
+
+                            checkbox = $('<input type="checkbox" name="sync_services[]">').val(output.service_id);
+                            checkbox.prop("checked", output.checked);
+                            if (output.highlight) {
+                                new_row.css("background-color", "yellow");
+                            }
+
+                            new_row.append($('<td></td>').append(checkbox))
+                            new_row.append($('<td></td>').text(output.domain));
+                            new_row.append($('<td></td>').text(output.date_before));
+                            new_row.append($('<td></td>').text(output.date_after));
+                            $('tbody#domain_changes').append(new_row);
+                        } else if(output.hasOwnProperty("error") && output.error){
+                            new_row = $('<tr></tr>');
+                            new_row.append($('<td></td>').text(output.domain));
+                            new_row.append($('<td></td>').text(output.error.detail));
+                            $('tbody#domain_errors').append(new_row);
+                        }
+                        services_done++;
+                        $('span#services_done').text(services_done);
+                        setTimeout(run_check, 100);
+                    });
+                }
+            };
+        </script>  
         <?php
         if (isset($_REQUEST['msg'])) {
             if ($_REQUEST['msg'] == 'success') { ?>
@@ -15,70 +69,36 @@
         $this->Widget->create($this->_('Namesilo.manage.sync_renew_dates.box_title', true));
         ?>
             <div class="inner">
+                <p>Services checked:<span id="services_done">0</span>/<span id="services_total">0</span></p>
                 <p><?php echo $this->_('Namesilo.manage.sync_renew_dates.description', true); ?></p>
-                <?php if (count($vars['changes']) > 0) { ?>
-                    <div class="title_row first">
-                        <h3><?php $this->_('Namesilo.manage.sync_renew_dates.out_of_sync'); ?></h3>
-                    </div>
-                    <?php $this->Form->create(); ?>
-                    <table class="table">
-                        <tbody>
-                        <tr class="heading_row">
-                            <td></td>
-                            <td><?php echo $this->_('Namesilo.domain.domain', true); ?></td>
-                            <td>Old Renew Date</td>
-                            <td>New Renew Date</td>
-                        </tr>
-                        <?php
-                        foreach ($vars['changes'] as $change) {
-                            if (isset($change['error']) && !$change['error']) {
-                                ?>
-                                <tr>
-                                    <td>
-                                        <?php
-                                        $this->Form->fieldCheckbox('sync_services[]', $this->Html->ifSet($change['service_id']), 'true');
-                                        ?>
-                                    </td>
-                                    <td><?php echo $this->Html->ifSet($change['domain']); ?></td>
-                                    <td><?php echo $this->Html->ifSet($change['date_before']); ?></td>
-                                    <td><?php echo $this->Html->ifSet($change['date_after']); ?></td>
-                                </tr>
-                                <?php
-                            }
-                        }
-                        ?>
-                        </tbody>
-                    </table>
-                    <div class="button_row"><a class="btn btn-primary pull-right submit" href="#"><?php $this->_('Namesilo.manage.sync_renew_dates.sync_btn'); ?></a></div>
-                    <?php $this->Form->end(); ?>
-                <?php } ?>
+                <div class="title_row first">
+                    <h3><?php $this->_('Namesilo.manage.sync_renew_dates.out_of_sync'); ?></h3>
+                </div>
+                <?php $this->Form->create(); ?>
+                <table class="table">
+                    <tbody id="domain_changes">
+                    <tr class="heading_row">
+                        <td></td>
+                        <td><?php echo $this->_('Namesilo.domain.domain', true); ?></td>
+                        <td>Old Renew Date</td>
+                        <td>New Renew Date</td>
+                    </tr>
+                    </tbody>
+                </table>
+                <div class="button_row"><a class="btn btn-primary pull-right submit" href="#"><?php $this->_('Namesilo.manage.sync_renew_dates.sync_btn'); ?></a></div>
+                <?php $this->Form->end(); ?>
 
-                <?php if (count($vars['changes']) > 0) { ?>
-                    <div class="title_row first" style="margin-top:15px !important">
-                        <h3><?php $this->_('Namesilo.manage.sync_renew_dates.errors'); ?></h3>
-                    </div>
-                    <table class="table">
-                        <tbody>
-                        <tr class="heading_row">
-                            <td><?php echo $this->_('Namesilo.domain.domain', true); ?></td>
-                            <td>Result</td>
-                        </tr>
-                        <?php
-                        foreach ($vars['changes'] as $change) {
-                            if (isset($change['error']) && $change['error']) {
-                                ?>
-                                <tr>
-                                    <td><?php echo $this->Html->ifSet($change['domain']); ?></td>
-                                    <td><?php echo $this->Html->ifSet($change['error']['detail']); ?></td>
-                                </tr>
-                                <?php
-                            }
-                        }
-                        ?>
-                        </tbody>
-                    </table>
-                <?php } ?>
-
+                <div class="title_row first" style="margin-top:15px !important">
+                    <h3><?php $this->_('Namesilo.manage.sync_renew_dates.errors'); ?></h3>
+                </div>
+                <table class="table">
+                    <tbody id="domain_errors">
+                    <tr class="heading_row">
+                        <td><?php echo $this->_('Namesilo.domain.domain', true); ?></td>
+                        <td>Result</td>
+                    </tr>
+                    </tbody>
+                </table>
             </div>
         <?php
         $this->Widget->end();

--- a/views/default/sync_renew_dates.pdt
+++ b/views/default/sync_renew_dates.pdt
@@ -1,5 +1,5 @@
         <script>
-            var service_ids = JSON.parse('<?php echo json_encode($this->Html->ifSet($vars['service_ids']), '[]'); ?>');
+            var service_ids = JSON.parse('<?php echo json_encode($vars['service_ids']); ?>');
             var services_done = 0;
 
             $(function() {


### PR DESCRIPTION
Audit Domains did not display the domain names due to an incorrect
variable.

Sync Renew Dates would timeout if you had a large number of domains to
check. The page now loads before checking each domain individually via
javascript requests.