### PR TITLE
Prevent premium domains from being sold

### DIFF
--- a/apis/namesilo_response.php
+++ b/apis/namesilo_response.php
@@ -47,6 +47,18 @@ class NamesiloResponse
     }
 
     /**
+     * Returns the CommandResponse in XML
+     * @return SimpleXMLElement A SimpleXMLElement object representing the CommandResponses, null if invalid response
+     */
+    public function responseXML()
+    {
+        if ($this->xml && $this->xml instanceof SimpleXMLElement) {
+            return $this->xml->reply;
+        }
+        return null;
+    }
+
+    /**
      * Returns the status of the API Responses
      *
      * @return string The status (300 = success)

--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -157,7 +157,7 @@ $lang['Namesilo.!error.key.valid_connection'] = 'The user and key combination ap
 $lang['Namesilo.!error.portfolio.valid_portfolio'] = 'The portfolio entered does not appear valid.  Are you sure it has been created in your Namesilo account?';
 $lang['Namesilo.!error.payment_id.valid_format'] = 'Payment ID must be either blank or numeric only.';
 $lang['Namesilo.!error.epp.empty'] = 'Domain transfers require an EPP code to be entered.';
-
+$lang['Namesilo.!error.permium_domain'] = '%1$s is a premium domain. Please contact us for more information.'; // %1$s is the premium domain;
 
 // Notices
 $lang['Namesilo.notice.StatusPending'] = 'This order is pending. The feature you are trying to access will become available once the order has been activated successfully.';

--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -157,7 +157,7 @@ $lang['Namesilo.!error.key.valid_connection'] = 'The user and key combination ap
 $lang['Namesilo.!error.portfolio.valid_portfolio'] = 'The portfolio entered does not appear valid.  Are you sure it has been created in your Namesilo account?';
 $lang['Namesilo.!error.payment_id.valid_format'] = 'Payment ID must be either blank or numeric only.';
 $lang['Namesilo.!error.epp.empty'] = 'Domain transfers require an EPP code to be entered.';
-$lang['Namesilo.!error.permium_domain'] = '%1$s is a premium domain. Please contact us for more information.'; // %1$s is the premium domain;
+$lang['Namesilo.!error.premium_domain'] = '%1$s is a premium domain. Please contact us for more information.'; // %1$s is the premium domain;
 
 // Notices
 $lang['Namesilo.notice.StatusPending'] = 'This order is pending. The feature you are trying to access will become available once the order has been activated successfully.';

--- a/namesilo.php
+++ b/namesilo.php
@@ -2221,11 +2221,21 @@ class Namesilo extends Module
             return false;
         }
 
-        $response = $result->response();
+        $responseXML = $result->responseXML();
+        $xpath_result = $responseXML->xpath("//available/domain[text()='" . $domain . "']");
 
-        $available = isset($response->available->{'domain'}) && $response->available->{'domain'} == $domain;
+        if (empty($xpath_result)) {
+            // The domain was not in the available element, its not available.
+            return false;
+        }
 
-        return $available;
+        $attributes = $xpath_result[0]->attributes();
+        if (isset($attributes->premium) && $attributes->premium == "1") {
+            $this->Input->setErrors(['premium' => Language::_('Namesilo.!error.permium_domain', true, $domain)]);
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/namesilo.php
+++ b/namesilo.php
@@ -2231,7 +2231,7 @@ class Namesilo extends Module
 
         $attributes = $xpath_result[0]->attributes();
         if (isset($attributes->premium) && $attributes->premium == "1") {
-            $this->Input->setErrors(['premium' => Language::_('Namesilo.!error.permium_domain', true, $domain)]);
+            $this->Input->setErrors(['availability' => ['premium' => Language::_('Namesilo.!error.permium_domain', true, $domain)]]);
             return false;
         }
 


### PR DESCRIPTION
Premium domains are available through NameSilo, but the prices are
different and won't match what package prices are based on.
The NameSilo API returns if a domain is premium or not in the XML
response as an attribute.