### PR TITLE
Fixes #59.

### DIFF
--- a/namesilo.php
+++ b/namesilo.php
@@ -995,7 +995,6 @@ class Namesilo extends Module
                     ];
                 }
             }
-			#die(var_export( $meta, true ) );
 
             return $meta;
         }

--- a/namesilo.php
+++ b/namesilo.php
@@ -973,7 +973,7 @@ class Namesilo extends Module
         $encrypted_fields = ['key'];
 
         // Merge package settings on to the module row meta
-        $module_row_meta = array_merge($vars, (array)$module_row->meta);
+        $module_row_meta = array_merge((array)$module_row->meta, $vars);
 
         // Set unspecified checkboxes
         if (empty($meta['sandbox'])) {
@@ -995,6 +995,7 @@ class Namesilo extends Module
                     ];
                 }
             }
+			#die(var_export( $meta, true ) );
 
             return $meta;
         }


### PR DESCRIPTION
Edit Namesilo Account information (Basic Settings), change Payment ID. New Payment ID is not saved. Commit fixes this issue.