### PR TITLE
added a way for admin to update EPP Code

### DIFF
--- a/apis/commands/domains_transfer.php
+++ b/apis/commands/domains_transfer.php
@@ -65,6 +65,20 @@ class NamesiloDomainsTransfer
     }
 
     /**
+     * Updates Epp code
+     *
+     * @param array $vars An array of input params including:
+     *
+     *  - auth The EPP Code
+     *  - domain The domain that is being transfered
+     * @return NamesiloResponse
+     */
+    public function updateEpp(array $vars)
+    {
+        return $this->api->submit('transferUpdateChangeEPPCode', $vars);
+    }
+
+    /**
      * Gets the status of a particular transfer.
      *
      * @param array $vars An array of input params including:

--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -140,6 +140,7 @@ $lang['Namesilo.tab_settings.field_resend_verification_email'] = 'Resend Verific
 $lang['Namesilo.tab_adminactions.title'] = 'Admin Actions';
 $lang['Namesilo.tab_adminactions.field_submit'] = 'Send Selected Notice';
 $lang['Namesilo.tab_adminactions.sync_date'] = 'Synchronize Renew Date';
+$lang['Namesilo.tab_adminactions.update.epp_code'] = 'Update EPP Code';
 
 $lang['Namesilo.manage.manual_renewal'] = 'Manually Renew (select years)';
 

--- a/namesilo.php
+++ b/namesilo.php
@@ -1715,6 +1715,14 @@ class Namesilo extends RegistrarModule
             if (!empty($post['notice'])) {
                 $communication->send($post);
             }
+            if (!empty($post['eppCode'])) {
+                $domains_transfer = new NamesiloDomainsTransfer($api);
+                $epp_vars['domain'] = $fields->domain;
+                $epp_vars['auth'] = $post['eppCode'];
+
+                $transfer_info = $domains_transfer->updateEpp($epp_vars);
+                $this->processResponse($api, $transfer_info);
+            }
             if (isset($post['action']) && $post['action'] == 'sync_date') {
                 Loader::loadModels($this, ['Services']);
 

--- a/views/default/tab_admin_actions.pdt
+++ b/views/default/tab_admin_actions.pdt
@@ -14,6 +14,17 @@
                 <?php $this->Form->fieldHidden('action', 'sync_date'); ?>
                 <div class="button_row"><a class="btn btn-primary submit" href="#"><?php $this->_('Namesilo.tab_adminactions.sync_date'); ?></a></div>
             </li>
+            <?php
+            $this->Form->end();
+            $this->Form->create();
+            ?>
+            <li class="pt-3">
+                <?php $this->Form->label('New EPP code', 'eppCode'); ?>
+                <?php $this->Form->fieldText('eppCode', '', ['id' => 'eppCode']); ?>
+                <div class="button_row"><a class="btn btn-primary submit" href="#"><?php $this->_('Namesilo.tab_adminactions.update.epp_code'); ?></a></div>
+            </li>
+            <?php
+            $this->Form->end();
+            ?>
         </ul>
-
     </div>


### PR DESCRIPTION
When clients enter domain transfer they do not always enter the correct EPP Code. This update allows staff to update EPP Code from Blesta without giving staff access to namesilo. 