### PR TITLE
move button up to match client side

### DIFF
--- a/views/default/tab_settings.pdt
+++ b/views/default/tab_settings.pdt
@@ -23,17 +23,17 @@
                 <li>
                     <?php $this->Form->fieldHidden('resend_verification_email', (isset($vars->registrant_verification_info['email_address']) ? $vars->registrant_verification_info['email_address'] : null)); ?>
                 </li>
+                <li>
+                <div class="button_row">
+                    <a class="btn btn-primary float-right submit" href="#"><?php $this->_('Namesilo.tab_settings.field_resend_verification_email'); ?></a>
+                </div>
+                </li>
                 <?php
             }
             ?>
         </ul>
     </div>
-    <?php if ((isset($vars->registrant_verification_info['verified']) ? $vars->registrant_verification_info['verified'] : null) == 'No') { ?>
-        <div class="button_row">
-            <a class="btn btn-primary float-right submit" href="#"><?php $this->_('Namesilo.tab_settings.field_resend_verification_email'); ?></a>
-        </div>
-        <?php
-    }
+    <?php
     $this->Form->end();
 
     if ($epp_code ?? false) {


### PR DESCRIPTION
@JReissmueller Simple a change to move button code closer to related code, plus it prevents an odd issue where an admin needs to click resend email button but it doesn't show up. This also matches the client side as it should. 