### PR TITLE
add post actions to client side

### DIFF
--- a/language/en_us/namesilo.php
+++ b/language/en_us/namesilo.php
@@ -113,6 +113,7 @@ $lang['Namesilo.tab_dnsrecord.help_text_1'] = 'On this page you can add or delet
 $lang['Namesilo.dnsrecord.record_type'] = 'Type';
 $lang['Namesilo.dnsrecord.host'] = 'Host';
 $lang['Namesilo.dnsrecord.value'] = 'Value';
+$lang['Namesilo.dnsrecord.distance'] = 'Priority';
 $lang['Namesilo.dnsrecord.ttl'] = 'TTL';
 $lang['Namesilo.dnsrecord.field_delete'] = 'Delete Record(s)';
 

--- a/namesilo.php
+++ b/namesilo.php
@@ -2305,28 +2305,25 @@ class Namesilo extends RegistrarModule
 
         if (!empty($post)) {
             if (isset($post['action'])) {
+                $dns_fields = [
+                    'domain' => $fields->domain,
+                    'rrtype' => $post['record_type'],
+                    'rrhost' => $post['host'],
+                    'rrvalue' => $post['value'],
+                    'rrttl' => $post['ttl'],
+                ];
+                if (isset($post['record_id']) && !empty($post['record_id'])) {
+                    $dns_fields['rrid'] = $post['record_id'];
+                }
+                if (isset($post['distance']) && !empty($post['distance']) && $post['record_type'] == 'MX') {
+                    $dns_fields['rrdistance'] = $post['distance'];
+                }
+
                 if ($post['action'] == 'addDnsRecord') {
-                    $response = $dns->dnsAddRecord(
-                        [
-                            'domain' => $fields->domain,
-                            'rrtype' => $post['record_type'],
-                            'rrhost' => $post['host'],
-                            'rrvalue' => $post['value'],
-                            'rrttl' => $post['ttl'],
-                        ]
-                    );
+                    $response = $dns->dnsAddRecord($dns_fields);
                     $this->processResponse($api, $response);
                 } elseif ($post['action'] == 'updateDnsRecord') {
-                    $response = $dns->dnsUpdateRecord(
-                        [
-                            'domain' => $fields->domain,
-                            'rrid' => $post['record_id'],
-                            'rrtype' => $post['record_type'],
-                            'rrhost' => $post['host'],
-                            'rrvalue' => $post['value'],
-                            'rrttl' => $post['ttl'],
-                        ]
-                    );
+                    $response = $dns->dnsUpdateRecord($dns_fields);
                     $this->processResponse($api, $response);
                 } elseif ($post['action'] == 'deleteDnsRecord') {
                     $response = $dns->dnsDeleteRecord(

--- a/namesilo.php
+++ b/namesilo.php
@@ -2305,24 +2305,12 @@ class Namesilo extends RegistrarModule
 
         if (!empty($post)) {
             if (isset($post['action'])) {
-                $dns_fields = [
-                    'domain' => $fields->domain,
-                    'rrtype' => $post['record_type'],
-                    'rrhost' => $post['host'],
-                    'rrvalue' => $post['value'],
-                    'rrttl' => $post['ttl'],
-                ];
-                if (isset($post['record_id']) && !empty($post['record_id'])) {
-                    $dns_fields['rrid'] = $post['record_id'];
-                }
-                if (isset($post['distance']) && !empty($post['distance']) && $post['record_type'] == 'MX') {
-                    $dns_fields['rrdistance'] = $post['distance'];
-                }
-
                 if ($post['action'] == 'addDnsRecord') {
+                    $dns_fields = $this->getDnsFields($post, $fields);
                     $response = $dns->dnsAddRecord($dns_fields);
                     $this->processResponse($api, $response);
                 } elseif ($post['action'] == 'updateDnsRecord') {
+                    $dns_fields = $this->getDnsFields($post, $fields);
                     $response = $dns->dnsUpdateRecord($dns_fields);
                     $this->processResponse($api, $response);
                 } elseif ($post['action'] == 'deleteDnsRecord') {
@@ -2361,6 +2349,24 @@ class Namesilo extends RegistrarModule
         $this->view->setDefaultView(self::$defaultModuleView);
 
         return $this->view->fetch();
+    }
+
+    private function getDnsFields($post, $fields) {
+        $dns_fields = [
+            'domain' => $fields->domain,
+            'rrtype' => $post['record_type'],
+            'rrhost' => $post['host'],
+            'rrvalue' => $post['value'],
+            'rrttl' => $post['ttl'],
+        ];
+        if (isset($post['record_id']) && !empty($post['record_id'])) {
+            $dns_fields['rrid'] = $post['record_id'];
+        }
+        if (isset($post['distance']) && !empty($post['distance']) && $post['record_type'] == 'MX') {
+            $dns_fields['rrdistance'] = $post['distance'];
+        }
+
+        return $dns_fields;
     }
 
     /**

--- a/views/default/tab_client_dnsrecords.pdt
+++ b/views/default/tab_client_dnsrecords.pdt
@@ -67,7 +67,7 @@
             <label><?php $this->_('Namesilo.dnsrecord.value');?><?php $this->Form->fieldText('value', null, ['class' => 'form-control']);?></label>
             <label><?php $this->_('Namesilo.dnsrecord.ttl');?><?php $this->Form->fieldText('ttl', 7207, ['class' => 'form-control']);?></label>
         </div>
-        <button class="btn btn-light float-right" type="submit">
+        <button class="btn btn-light float-right" type="submit" name="action" value="addDnsRecord">
             <i class="fas fa-edit"></i> <?php $this->_('Namesilo.tab_dnsrecord.field_add'); ?>
         </button>
         <?php

--- a/views/default/tab_client_dnsrecords.pdt
+++ b/views/default/tab_client_dnsrecords.pdt
@@ -9,6 +9,7 @@
                         <th><span><?php $this->_('Namesilo.dnsrecord.record_type');?></span></th>
                         <th><span><?php $this->_('Namesilo.dnsrecord.host');?></span></th>
                         <th><span><?php $this->_('Namesilo.dnsrecord.value');?></span></th>
+                        <th><span><?php $this->_('Namesilo.dnsrecord.distance');?></span></th>
                         <th><span><?php $this->_('Namesilo.dnsrecord.ttl');?></span></th>
                         <th><span><?php $this->_('Namesilo.dnsrecord.field_delete');?></span></th>
                     </tr>
@@ -23,6 +24,7 @@
                                 <td><?php echo (isset($record['type']) ? $record['type'] : null);?></td>
                                 <td><?php echo (isset($record['host']) ? $record['host'] : null);?></td>
                                 <td><?php echo (isset($record['value']) ? $record['value'] : null);?></td>
+                                <td><?php echo (isset($record['distance']) && $record['distance'] != 0 ? $record['distance'] : null);?></td>
                                 <td><?php echo (isset($record['ttl']) ? $record['ttl'] : null);?></td>
                                 <td>
                                     <?php
@@ -65,8 +67,10 @@
             <label><?php $this->_('Namesilo.dnsrecord.record_type');?><?php $this->Form->fieldSelect('record_type', $vars->selects['record_type']['options'], null, ['class' => 'form-control']);?></label>
             <label><?php $this->_('Namesilo.dnsrecord.host');?><?php $this->Form->fieldText('host', null, ['class' => 'form-control']);?></label>
             <label><?php $this->_('Namesilo.dnsrecord.value');?><?php $this->Form->fieldText('value', null, ['class' => 'form-control']);?></label>
+            <label id="distance" style="display:none;"><?php $this->_('Namesilo.dnsrecord.distance');?><?php $this->Form->fieldText('distance', 10, ['class' => 'form-control']);?></label>
             <label><?php $this->_('Namesilo.dnsrecord.ttl');?><?php $this->Form->fieldText('ttl', 7207, ['class' => 'form-control']);?></label>
         </div>
+
         <button class="btn btn-light float-right" type="submit" name="action" value="addDnsRecord">
             <i class="fas fa-edit"></i> <?php $this->_('Namesilo.tab_dnsrecord.field_add'); ?>
         </button>
@@ -74,3 +78,15 @@
         $this->Form->end();
         ?>
     </div>
+
+    <script>
+        $(document).ready(function() {
+            $('[name="record_type"]').on('change', function() {
+                if($(this).val() == 'MX') {
+                    $('#distance').show()
+                } else {
+                    $('#distance').hide()
+                }
+            })
+        })
+    </script>

--- a/views/default/tab_client_dnssec.pdt
+++ b/views/default/tab_client_dnssec.pdt
@@ -64,7 +64,7 @@
                 <label><?php $this->_('Namesilo.dnssec.digest'); ?><?php $this->Form->fieldText('digest', null, ['class' => 'form-control']); ?></label>
             </div>
 
-            <button class="btn btn-light float-right" type="submit">
+            <button class="btn btn-light float-right" type="submit" name="action" value="addDnssec">
                 <i class="fas fa-edit"></i> <?php $this->_('Namesilo.tab_dnssec.field_add'); ?>
             </button>
         <?php

--- a/views/default/tab_dnsrecords.pdt
+++ b/views/default/tab_dnsrecords.pdt
@@ -9,6 +9,7 @@
                     <td><span><?php $this->_('Namesilo.dnsrecord.record_type');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.host');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.value');?></span></td>
+                    <td><span><?php $this->_('Namesilo.dnsrecord.distance');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.ttl');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.field_delete');?></span></td>
                 </tr>
@@ -23,6 +24,7 @@
                         <td><?php echo (isset($record['type']) ? $record['type'] : null);?></td>
                         <td><?php echo (isset($record['host']) ? $record['host'] : null);?></td>
                         <td><?php echo (isset($record['value']) ? $record['value'] : null);?></td>
+                        <td><?php echo (isset($record['distance']) && $record['distance'] != 0 ? $record['distance'] : null);?></td>
                         <td><?php echo (isset($record['ttl']) ? $record['ttl'] : null);?></td>
                         <td>
                             <?php
@@ -72,6 +74,7 @@
                     <td><span><?php $this->_('Namesilo.dnsrecord.record_type');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.host');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.value');?></span></td>
+                    <td class="distance" style="display:none;"><span><?php $this->_('Namesilo.dnsrecord.distance');?></span></td>
                     <td><span><?php $this->_('Namesilo.dnsrecord.ttl');?></span></td>
                     <td></td>
                 </tr>
@@ -81,6 +84,7 @@
                     <td><?php $this->Form->fieldSelect('record_type', $vars->selects['record_type']['options']);?></td>
                     <td><?php $this->Form->fieldText('host');?></td>
                     <td><?php $this->Form->fieldText('value');?></td>
+                    <td class="distance" style="display:none;"><?php $this->Form->fieldText('distance', 10);?></td>
                     <td><?php $this->Form->fieldText('ttl', 7207);?></td>
                     <td>
                         <?php
@@ -105,3 +109,15 @@
         $this->Form->end();
         ?>
     </div>
+
+    <script>
+        $(document).ready(function() {
+            $('[name="record_type"]').on('change', function() {
+                if($(this).val() == 'MX') {
+                    $('.distance').show()
+                } else {
+                    $('.distance').hide()
+                }
+            })
+        })
+    </script>


### PR DESCRIPTION
There was missing actions on add buttons in DNS Records and DNS Sec clients views.
I also had to refactor a bit, to add the ability for clients and admins to add Priority which is labeled distance in namesilo