### PR TITLE
update sandbox link

### DIFF
--- a/apis/namesilo_api.php
+++ b/apis/namesilo_api.php
@@ -23,7 +23,7 @@ class NamesiloApi
     // Load traits
     use Container;
 
-    const SANDBOX_URL = 'https://sandbox.namesilo.com/api';
+    const SANDBOX_URL = 'https://ote.namesilo.com/api';
     const LIVE_URL = 'https://www.namesilo.com/api';
 
     /**


### PR DESCRIPTION
The Namesilo sandbox link has changed, all the calls stayed the same as far as I know/tested